### PR TITLE
Fixed deprecation of `gftools`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ the source code, the follow the following instructions.
 
 2. Download and install:<br>
 **fontmake** which can be found [here](https://github.com/googlei18n/fontmake)<br>
-**gftools** which can be found [here](https://github.com/googlefonts/gftools)<br>
+**gftools** which can be found [here](https://github.com/googlefonts/gftools) (at least 0.9.26)<br>
 **ttfautohint** which can be found [here](https://www.freetype.org/ttfautohint/)<br>
 
 3. Run the build.sh script located in the "scripts" folder. This should make both the variable and non-variable versions of the font.

--- a/scripts/build-GF.sh
+++ b/scripts/build-GF.sh
@@ -64,8 +64,6 @@ fontmake -o ufo -i "900i" -m ../sources-GF/designspace/jost.designspace
 echo "Generating TrueType Fonts"
 fontmake  -o ttf --output-dir ../fonts/ttf2/ -u ../sources-GF/instances/100.ufo ../sources-GF/instances/100i.ufo ../sources-GF/instances/200.ufo ../sources-GF/instances/200i.ufo ../sources-GF/instances/300.ufo ../sources-GF/instances/300i.ufo ../sources-GF/instances/400.ufo ../sources-GF/instances/400i.ufo ../sources-GF/instances/500.ufo ../sources-GF/instances/500i.ufo ../sources-GF/instances/600.ufo ../sources-GF/instances/600i.ufo ../sources-GF/instances/700.ufo ../sources-GF/instances/700i.ufo ../sources-GF/instances/800.ufo ../sources-GF/instances/800i.ufo ../sources-GF/instances/900.ufo ../sources-GF/instances/900i.ufo
 
-echo "Hot Fixes"
-gftools fix-dsig -f ../fonts/ttf2/*.ttf
 
 mkdir -p ../fonts/static
 
@@ -151,10 +149,7 @@ echo "vf cleaning"
 vfs=$(ls ../fonts/*.ttf)
 for vf in $vfs
 do
-gftools fix-dsig -f $vf;
 gftools fix-nonhinting $vf "$vf.fix";
-mv "$vf.fix" $vf;
-gftools fix-vf-meta $vf;
 mv "$vf.fix" $vf;
 done
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,7 +12,6 @@ echo "vf cleaning"
 vfs=$(ls ../fonts/*.ttf)
 for vf in $vfs
 do
-gftools fix-dsig -f $vf;
 gftools fix-nonhinting $vf "$vf.fix";
 mv "$vf.fix" $vf;
 done
@@ -43,9 +42,6 @@ fontmake -o ufo -i "900i" -m ../sources/designspace/jost.designspace
 
 echo "Generating TrueType Fonts"
 fontmake  -o ttf --output-dir ../fonts/ttf2/ -u ../sources/instances/100.ufo ../sources/instances/100i.ufo ../sources/instances/200.ufo ../sources/instances/200i.ufo ../sources/instances/300.ufo ../sources/instances/300i.ufo ../sources/instances/400.ufo ../sources/instances/400i.ufo ../sources/instances/500.ufo ../sources/instances/500i.ufo ../sources/instances/600.ufo ../sources/instances/600i.ufo ../sources/instances/700.ufo ../sources/instances/700i.ufo ../sources/instances/800.ufo ../sources/instances/800i.ufo ../sources/instances/900.ufo ../sources/instances/900i.ufo
-
-echo "Hot Fixes"
-gftools fix-dsig -f ../fonts/ttf2/*.ttf
 
 mkdir -p ../fonts/ttf
 


### PR DESCRIPTION
Removed deprecated commands on `gftools` and updated `README.md` to take into account the version of `gftools` to be installed`. This PR fixes #100 