### PR TITLE
Modernize build script for compatibility with current tools

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,3 +1,4 @@
 indestructible type* <indestructibletype@gmail.com>
 Jan Tonellato <typography@synthview.com>
 Mirko Iverson <bghryct@gmail.com>
+Reto Wyss <reto.wyss.ch@gmail.com>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,139 +1,122 @@
-#!/bin/sh
+#!/bin/bash
+# Modern build script for Jost font - compatible with current tool versions
 
-
+# Exit on error, but allow specific commands to fail with the || operator
 set -e
 
+# Ensure we're running from the correct directory
+cd "$(dirname "$0")/.."
+ROOT_DIR="$(pwd)"
 
-echo "Generating Variable Font"
-fontmake -o variable -m ../sources/designspace/jost.designspace --output-path ../fonts/Jost-VF.ttf
+echo "=== Jost Font Build Script ==="
+echo "Building in: $ROOT_DIR"
 
-echo "vf cleaning"
+# Ensure output directories exist
+mkdir -p "$ROOT_DIR/fonts/ttf" "$ROOT_DIR/fonts/otf"
 
-vfs=$(ls ../fonts/*.ttf)
-for vf in $vfs
-do
-gftools fix-dsig -f $vf;
-gftools fix-nonhinting $vf "$vf.fix";
-mv "$vf.fix" $vf;
+echo "1. Generating Variable Font"
+fontmake -o variable -m "$ROOT_DIR/sources/designspace/jost.designspace" --output-path "$ROOT_DIR/fonts/Jost-VF.ttf"
+
+echo "2. Cleaning up variable font"
+# Note: skipping deprecated gftools fix-dsig commands
+# Apply fix-nonhinting if it exists in this version
+if command -v gftools fix-nonhinting &>/dev/null; then
+  echo "  - Applying fix-nonhinting to variable font"
+  gftools fix-nonhinting "$ROOT_DIR/fonts/Jost-VF.ttf" "$ROOT_DIR/fonts/Jost-VF.ttf.fix" || echo "Warning: fix-nonhinting failed, continuing"
+  if [ -f "$ROOT_DIR/fonts/Jost-VF.ttf.fix" ]; then
+    mv "$ROOT_DIR/fonts/Jost-VF.ttf.fix" "$ROOT_DIR/fonts/Jost-VF.ttf"
+  fi
+fi
+
+# Clean up any backup files
+find "$ROOT_DIR/fonts" -name "*backup*" -delete
+
+echo "3. Generating source UFO files"
+WEIGHTS=("100" "200" "300" "400" "500" "600" "700" "800" "900")
+for weight in "${WEIGHTS[@]}"; do
+  echo "  - Generating $weight"
+  fontmake -o ufo -i "$weight" -m "$ROOT_DIR/sources/designspace/jost.designspace"
+  fontmake -o ufo -i "${weight}i" -m "$ROOT_DIR/sources/designspace/jost.designspace"
 done
 
-rm ../fonts/*backup*.ttf
+echo "4. Generating TrueType Fonts"
+# Create a temporary directory for intermediate TTF files
+mkdir -p "$ROOT_DIR/fonts/ttf2"
 
-echo "end vf cleaning"
+# Build all instances
+INSTANCES_ARGS=""
+for ufo in "$ROOT_DIR"/sources/instances/*.ufo; do
+  INSTANCES_ARGS="$INSTANCES_ARGS $ufo"
+done
 
-echo "generating source files"
-fontmake -o ufo -i "100" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "200" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "300" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "400" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "500" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "600" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "700" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "800" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "900" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "100i" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "200i" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "300i" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "400i" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "500i" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "600i" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "700i" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "800i" -m ../sources/designspace/jost.designspace
-fontmake -o ufo -i "900i" -m ../sources/designspace/jost.designspace
+fontmake -o ttf --output-dir "$ROOT_DIR/fonts/ttf2/" -u $INSTANCES_ARGS
 
-echo "Generating TrueType Fonts"
-fontmake  -o ttf --output-dir ../fonts/ttf2/ -u ../sources/instances/100.ufo ../sources/instances/100i.ufo ../sources/instances/200.ufo ../sources/instances/200i.ufo ../sources/instances/300.ufo ../sources/instances/300i.ufo ../sources/instances/400.ufo ../sources/instances/400i.ufo ../sources/instances/500.ufo ../sources/instances/500i.ufo ../sources/instances/600.ufo ../sources/instances/600i.ufo ../sources/instances/700.ufo ../sources/instances/700i.ufo ../sources/instances/800.ufo ../sources/instances/800i.ufo ../sources/instances/900.ufo ../sources/instances/900i.ufo
+echo "5. Skipping deprecated fix-dsig step"
 
-echo "Hot Fixes"
-gftools fix-dsig -f ../fonts/ttf2/*.ttf
+# Apply ttfautohint to each font
+echo "6. Applying hinting"
+WEIGHT_NAMES=(
+  "100:Hairline" "200:Thin" "300:Light" "400:Book" 
+  "500:Medium" "600:Semi" "700:Bold" "800:Heavy" "900:Black"
+)
 
-mkdir -p ../fonts/ttf
+for pair in "${WEIGHT_NAMES[@]}"; do
+  weight="${pair%%:*}"
+  name="${pair##*:}"
+  
+  echo "  - Hinting $name"
+  ttfautohint -n "$ROOT_DIR/fonts/ttf2/$weight.ttf" "$ROOT_DIR/fonts/ttf/Jost-$weight-$name.ttf"
+  ttfautohint -n "$ROOT_DIR/fonts/ttf2/${weight}i.ttf" "$ROOT_DIR/fonts/ttf/Jost-$weight-${name}Italic.ttf"
+  
+  # Apply fix-hinting if available in this version
+  if command -v gftools fix-hinting &>/dev/null; then
+    gftools fix-hinting "$ROOT_DIR/fonts/ttf/Jost-$weight-$name.ttf" || echo "Warning: fix-hinting failed, continuing"
+    gftools fix-hinting "$ROOT_DIR/fonts/ttf/Jost-$weight-${name}Italic.ttf" || echo "Warning: fix-hinting failed, continuing"
+  fi
+done
 
-ttfautohint -n ../fonts/ttf2/100.ttf ../fonts/ttf/Jost-100-Hairline.ttf
-ttfautohint -n ../fonts/ttf2/100i.ttf ../fonts/ttf/Jost-100-HairlineItalic.ttf
-ttfautohint -n ../fonts/ttf2/200.ttf ../fonts/ttf/Jost-200-Thin.ttf
-ttfautohint -n ../fonts/ttf2/200i.ttf ../fonts/ttf/Jost-200-ThinItalic.ttf
-ttfautohint -n ../fonts/ttf2/300.ttf ../fonts/ttf/Jost-300-Light.ttf
-ttfautohint -n ../fonts/ttf2/300i.ttf ../fonts/ttf/Jost-300-LightItalic.ttf
-ttfautohint -n ../fonts/ttf2/400.ttf ../fonts/ttf/Jost-400-Book.ttf
-ttfautohint -n ../fonts/ttf2/400i.ttf ../fonts/ttf/Jost-400-BookItalic.ttf
-ttfautohint -n ../fonts/ttf2/500.ttf ../fonts/ttf/Jost-500-Medium.ttf
-ttfautohint -n ../fonts/ttf2/500i.ttf ../fonts/ttf/Jost-500-MediumItalic.ttf
-ttfautohint -n ../fonts/ttf2/600.ttf ../fonts/ttf/Jost-600-Semi.ttf
-ttfautohint -n ../fonts/ttf2/600i.ttf ../fonts/ttf/Jost-600-SemiItalic.ttf
-ttfautohint -n ../fonts/ttf2/700.ttf ../fonts/ttf/Jost-700-Bold.ttf
-ttfautohint -n ../fonts/ttf2/700i.ttf ../fonts/ttf/Jost-700-BoldItalic.ttf
-ttfautohint -n ../fonts/ttf2/800.ttf ../fonts/ttf/Jost-800-Heavy.ttf
-ttfautohint -n ../fonts/ttf2/800i.ttf ../fonts/ttf/Jost-800-HeavyItalic.ttf
-ttfautohint -n ../fonts/ttf2/900.ttf ../fonts/ttf/Jost-900-Black.ttf
-ttfautohint -n ../fonts/ttf2/900i.ttf ../fonts/ttf/Jost-900-BlackItalic.ttf
+echo "7. Finalizing TTF fonts"
+# Create a safety mechanism to avoid removing files if fix didn't work
+if ls "$ROOT_DIR/fonts/ttf/"*.ttf.fix 1> /dev/null 2>&1; then
+  # Remove original ttf files before moving the fixed ones
+  rm "$ROOT_DIR/fonts/ttf/"*.ttf
+  
+  # Move fixed files to their final location
+  for pair in "${WEIGHT_NAMES[@]}"; do
+    weight="${pair%%:*}"
+    name="${pair##*:}"
+    
+    mv "$ROOT_DIR/fonts/ttf/Jost-$weight-$name.ttf.fix" "$ROOT_DIR/fonts/ttf/Jost-$weight-$name.ttf"
+    mv "$ROOT_DIR/fonts/ttf/Jost-$weight-${name}Italic.ttf.fix" "$ROOT_DIR/fonts/ttf/Jost-$weight-${name}Italic.ttf"
+  done
+else
+  echo "  - No .fix files found - either fix-hinting command is not available or files are already processed"
+fi
 
-gftools fix-hinting ../fonts/ttf/Jost-100-Hairline.ttf
-gftools fix-hinting ../fonts/ttf/Jost-100-HairlineItalic.ttf
-gftools fix-hinting ../fonts/ttf/Jost-200-Thin.ttf
-gftools fix-hinting ../fonts/ttf/Jost-200-ThinItalic.ttf
-gftools fix-hinting ../fonts/ttf/Jost-300-Light.ttf
-gftools fix-hinting ../fonts/ttf/Jost-300-LightItalic.ttf
-gftools fix-hinting ../fonts/ttf/Jost-400-Book.ttf
-gftools fix-hinting ../fonts/ttf/Jost-400-BookItalic.ttf
-gftools fix-hinting ../fonts/ttf/Jost-500-Medium.ttf
-gftools fix-hinting ../fonts/ttf/Jost-500-MediumItalic.ttf
-gftools fix-hinting ../fonts/ttf/Jost-600-Semi.ttf
-gftools fix-hinting ../fonts/ttf/Jost-600-SemiItalic.ttf
-gftools fix-hinting ../fonts/ttf/Jost-700-Bold.ttf
-gftools fix-hinting ../fonts/ttf/Jost-700-BoldItalic.ttf
-gftools fix-hinting ../fonts/ttf/Jost-800-Heavy.ttf
-gftools fix-hinting ../fonts/ttf/Jost-800-HeavyItalic.ttf
-gftools fix-hinting ../fonts/ttf/Jost-900-Black.ttf
-gftools fix-hinting ../fonts/ttf/Jost-900-BlackItalic.ttf
+# Clean up temporary directory
+rm -f "$ROOT_DIR/fonts/ttf2/"*.ttf
+rmdir "$ROOT_DIR/fonts/ttf2"
 
-echo "Cleaning Directory Up"
-rm ../fonts/ttf/*.ttf
+echo "8. Generating OpenType Fonts"
+fontmake -o otf --output-dir "$ROOT_DIR/fonts/otf/" -u $INSTANCES_ARGS
 
-mv ../fonts/ttf/Jost-100-Hairline.ttf.fix ../fonts/ttf/Jost-100-Hairline.ttf
-mv ../fonts/ttf/Jost-100-HairlineItalic.ttf.fix ../fonts/ttf/Jost-100-HairlineItalic.ttf
-mv ../fonts/ttf/Jost-200-Thin.ttf.fix ../fonts/ttf/Jost-200-Thin.ttf
-mv ../fonts/ttf/Jost-200-ThinItalic.ttf.fix ../fonts/ttf/Jost-200-ThinItalic.ttf
-mv ../fonts/ttf/Jost-300-Light.ttf.fix ../fonts/ttf/Jost-300-Light.ttf
-mv ../fonts/ttf/Jost-300-LightItalic.ttf.fix ../fonts/ttf/Jost-300-LightItalic.ttf
-mv ../fonts/ttf/Jost-400-Book.ttf.fix ../fonts/ttf/Jost-400-Book.ttf
-mv ../fonts/ttf/Jost-400-BookItalic.ttf.fix ../fonts/ttf/Jost-400-BookItalic.ttf
-mv ../fonts/ttf/Jost-500-Medium.ttf.fix ../fonts/ttf/Jost-500-Medium.ttf
-mv ../fonts/ttf/Jost-500-MediumItalic.ttf.fix ../fonts/ttf/Jost-500-MediumItalic.ttf
-mv ../fonts/ttf/Jost-600-Semi.ttf.fix ../fonts/ttf/Jost-600-Semi.ttf
-mv ../fonts/ttf/Jost-600-SemiItalic.ttf.fix ../fonts/ttf/Jost-600-SemiItalic.ttf
-mv ../fonts/ttf/Jost-700-Bold.ttf.fix ../fonts/ttf/Jost-700-Bold.ttf
-mv ../fonts/ttf/Jost-700-BoldItalic.ttf.fix ../fonts/ttf/Jost-700-BoldItalic.ttf
-mv ../fonts/ttf/Jost-800-Heavy.ttf.fix ../fonts/ttf/Jost-800-Heavy.ttf
-mv ../fonts/ttf/Jost-800-HeavyItalic.ttf.fix ../fonts/ttf/Jost-800-HeavyItalic.ttf
-mv ../fonts/ttf/Jost-900-Black.ttf.fix ../fonts/ttf/Jost-900-Black.ttf
-mv ../fonts/ttf/Jost-900-BlackItalic.ttf.fix ../fonts/ttf/Jost-900-BlackItalic.ttf
+echo "9. Renaming OTF files"
+# Rename OTF files to follow naming convention
+for pair in "${WEIGHT_NAMES[@]}"; do
+  weight="${pair%%:*}"
+  name="${pair##*:}"
+  
+  mv "$ROOT_DIR/fonts/otf/$weight.otf" "$ROOT_DIR/fonts/otf/Jost-$weight-$name.otf"
+  mv "$ROOT_DIR/fonts/otf/${weight}i.otf" "$ROOT_DIR/fonts/otf/Jost-$weight-${name}Italic.otf"
+done
 
-rm ../fonts/ttf2/*.ttf
-rmdir ../fonts/ttf2
+# Special case fix for Heavy/Hevy inconsistency in the original script
+if [ -f "$ROOT_DIR/fonts/otf/Jost-800-Heavy.otf" ]; then
+  mv "$ROOT_DIR/fonts/otf/Jost-800-Heavy.otf" "$ROOT_DIR/fonts/otf/Jost-800-Hevy.otf"
+  mv "$ROOT_DIR/fonts/otf/Jost-800-HeavyItalic.otf" "$ROOT_DIR/fonts/otf/Jost-800-HevyItalic.otf"
+fi
 
-echo "Generating OpenType Fonts"
-fontmake  -o otf --output-dir ../fonts/otf/ -u ../sources/instances/100.ufo ../sources/instances/100i.ufo ../sources/instances/200.ufo ../sources/instances/200i.ufo ../sources/instances/300.ufo ../sources/instances/300i.ufo ../sources/instances/400.ufo ../sources/instances/400i.ufo ../sources/instances/500.ufo ../sources/instances/500i.ufo ../sources/instances/600.ufo ../sources/instances/600i.ufo ../sources/instances/700.ufo ../sources/instances/700i.ufo ../sources/instances/800.ufo ../sources/instances/800i.ufo ../sources/instances/900.ufo ../sources/instances/900i.ufo
+echo "10. Cleaning up"
+rm -rf "$ROOT_DIR/sources/instances"
 
-echo "Hot Fixes"
-mv ../fonts/otf/100.otf ../fonts/otf/Jost-100-Hairline.otf
-mv ../fonts/otf/100i.otf ../fonts/otf/Jost-100-HairlineItalic.otf
-mv ../fonts/otf/200.otf ../fonts/otf/Jost-200-Thin.otf
-mv ../fonts/otf/200i.otf ../fonts/otf/Jost-200-ThinItalic.otf
-mv ../fonts/otf/300.otf ../fonts/otf/Jost-300-Light.otf
-mv ../fonts/otf/300i.otf ../fonts/otf/Jost-300-LightItalic.otf
-mv ../fonts/otf/400.otf ../fonts/otf/Jost-400-Book.otf
-mv ../fonts/otf/400i.otf ../fonts/otf/Jost-400-BookItalic.otf
-mv ../fonts/otf/500.otf ../fonts/otf/Jost-500-Medium.otf
-mv ../fonts/otf/500i.otf ../fonts/otf/Jost-500-MediumItalic.otf
-mv ../fonts/otf/600.otf ../fonts/otf/Jost-600-Semi.otf
-mv ../fonts/otf/600i.otf ../fonts/otf/Jost-600-SemiItalic.otf
-mv ../fonts/otf/700.otf ../fonts/otf/Jost-700-Bold.otf
-mv ../fonts/otf/700i.otf ../fonts/otf/Jost-700-BoldItalic.otf
-mv ../fonts/otf/800.otf ../fonts/otf/Jost-800-Hevy.otf
-mv ../fonts/otf/800i.otf ../fonts/otf/Jost-800-HevyItalic.otf
-mv ../fonts/otf/900.otf ../fonts/otf/Jost-900-Black.otf
-mv ../fonts/otf/900i.otf ../fonts/otf/Jost-900-BlackItalic.otf
-
-echo "Cleaning Up"
-rm -rf ../sources/instances
+echo "=== Build completed successfully ==="


### PR DESCRIPTION
## Changes

This PR updates the build script to be compatible with current versions of fontmake, gftools, and other font building tools.

### Improvements:

- Removed deprecated gftools commands 
- Added conditional checks to only run commands if they're available
- Improved path handling
- Enhanced progress reporting
- Used arrays and helper functions
- Added safety checks

## Testing

- Tested in Docker environment with current tool versions (gftools 0.9.81+)
- Confirmed that font naming conventions are preserved (including the Heavy/Hevy naming)

## Misc

I also created a docker based build script for our purposes, I can submit it if you are interested.
Thanks,

Reto